### PR TITLE
Fixes for Slack v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-vsts-slack",
   "description": "A Hubot script for Visual Studio Team Services integration tailored for Slack",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "Nithin Shenoy <nshenoy@mimeo.com>",
   "license": "MIT",
   "keywords": "hubot, hubot-scripts, vsts, vso, Visual Studio Team Services",

--- a/src/vsts-slack.coffee
+++ b/src/vsts-slack.coffee
@@ -86,7 +86,7 @@ module.exports = (robot) ->
                                 for pr in pullRequests
                                     attachment = createPullRequestAttachment showDetails, pr, repositories[pr.repository.id], project                    
                                     
-                                    res.robot.adapter.customMessage
+                                    res.send
                                         channel: res.envelope.room
                                         username: res.robot.name
                                         attachments: [attachment]
@@ -138,7 +138,7 @@ module.exports = (robot) ->
                 pbiDetails = JSON.parse(body)
                 attachment = createPBIAttachment pbiDetails                    
                 
-                res.robot.adapter.customMessage
+                res.send
                     channel: res.envelope.room
                     username: res.robot.name
                     attachments: [attachment]


### PR DESCRIPTION
Slack v4 removed the customMessage and now handles attachments via the normal .send
